### PR TITLE
Add light mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   - [Setup Instructions](#setup-instructions)
   - [Run](#run)
   - [Background media:](#background-media)
+  - [Makefile available commands](#makefile-available-commands)
   - [Contributing](#contributing)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -90,6 +91,9 @@ Follow these steps to set up the project:
     SCREEN_HEIGHT=1920
     SCREEN_WIDTH=1080
     MIN_VIDEO_DURATION=70.0
+
+    # Others
+    PRESET=slow
     ```
 
     **Notes:**

--- a/src/config.py
+++ b/src/config.py
@@ -40,7 +40,7 @@ class Settings(BaseSettings):
     - SCREEN_WIDTH: The width of the screen in pixels.
     - PYTHONWARNINGS: The warnings to be ignored.
     - TOKENIZERS_PARALLELISM: The parallelism of the tokenizers.
-    - HAS_GPU: Whether a GPU is available for video processing.
+    - USE_GPU: Whether to use GPU for video processing.
     - PRESET: The preset for the video processing.
     """
 
@@ -60,7 +60,6 @@ class Settings(BaseSettings):
     # Others
     PYTHONWARNINGS: str = "ignore"
     TOKENIZERS_PARALLELISM: str = "true"
-    HAS_GPU: bool = False
     USE_GPU: bool = is_videotoolbox_available()
     PRESET: Literal["veryslow", "slow", "medium", "fast", "veryfast"] = "slow"
 

--- a/src/main.py
+++ b/src/main.py
@@ -62,7 +62,7 @@ def main():
     AUDIO_SPEED = (
         1.3  # TODO: we need to change this to use the video duration from settings.
     )
-    THEME = "dark"
+    THEME = "light"
 
     # POST
     # Get Reddit post
@@ -153,7 +153,7 @@ def main():
 
     # Get the comments screenshots
     for comment in top_comments:
-        asyncio.run(take_comment_screenshot(comment), THEME)
+        asyncio.run(take_comment_screenshot(comment, THEME))
 
     # Generate comments videos: combine audio and image
     for comment in top_comments:

--- a/src/main.py
+++ b/src/main.py
@@ -62,6 +62,7 @@ def main():
     AUDIO_SPEED = (
         1.3  # TODO: we need to change this to use the video duration from settings.
     )
+    THEME = "dark"
 
     # POST
     # Get Reddit post
@@ -124,7 +125,7 @@ def main():
     )
 
     # Get the post screenshot
-    asyncio.run(take_post_screenshot(post))
+    asyncio.run(take_post_screenshot(post, THEME))
 
     # Generate post video: combine audio and image
     create_image_videoclip(
@@ -152,7 +153,7 @@ def main():
 
     # Get the comments screenshots
     for comment in top_comments:
-        asyncio.run(take_comment_screenshot(comment))
+        asyncio.run(take_comment_screenshot(comment), THEME)
 
     # Generate comments videos: combine audio and image
     for comment in top_comments:

--- a/src/utils/reddit/screenshot.py
+++ b/src/utils/reddit/screenshot.py
@@ -50,7 +50,7 @@ async def login_reddit(context: BrowserContext, timeout: int = 5000) -> BrowserC
 async def build_browser_context(
     playwright_instance: async_playwright,
     url: str,
-    cookie_file_path: str,
+    theme: Literal["dark", "Light"] = "light",
     timeout: int = 5000,
 ) -> Tuple[BrowserContext, Browser]:
     """
@@ -66,12 +66,12 @@ async def build_browser_context(
     browser = await playwright_instance.chromium.launch(headless=True)
 
     # Cookies
-    cookie_file = open(cookie_file_path, encoding="utf-8")
+    cookie_file = open(f"./data/cookies/cookie-{theme}-mode.json", encoding="utf-8")
     dsf = (settings.SCREEN_WIDTH // 600) + 1
 
     context = await browser.new_context(
         locale="en-us",
-        color_scheme="dark",
+        color_scheme=theme,
         viewport={"width": settings.SCREEN_WIDTH, "height": settings.SCREEN_HEIGHT},
         device_scale_factor=dsf,
         user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",  # noqa: E501
@@ -104,7 +104,7 @@ async def build_browser_context(
 
 async def take_post_screenshot(
     post: RedditPost,
-    theme: Literal["dark", "light"] = "dark",
+    theme: Literal["dark", "light"] = "light",
 ) -> None:
     """
     Take and save a screenshot of the main post in a Reddit post/thread
@@ -119,11 +119,7 @@ async def take_post_screenshot(
         return
 
     async with async_playwright() as p:
-        context, browser = await build_browser_context(
-            p,
-            cookie_file_path=f"./data/cookies/cookie-{theme}-mode.json",
-            url=post.url,
-        )
+        context, browser = await build_browser_context(p, theme=theme, url=post.url)
         await context.locator("shreddit-post").screenshot(path=post.image_path)
         logger.info(f"Main post screenshot saved to: {post.image_path}")
         await browser.close()
@@ -154,7 +150,7 @@ def join_images_vertically(image_paths: list, output_path: str) -> None:
 
 async def take_comment_screenshot(
     comment: RedditComment,
-    theme: Literal["dark", "light"] = "dark",
+    theme: Literal["dark", "light"] = "light",
 ) -> None:
     """
     Take and save a screenshot of a comment, EXCLUDING replies.
@@ -168,11 +164,7 @@ async def take_comment_screenshot(
         return
 
     async with async_playwright() as p:
-        page, browser = await build_browser_context(
-            p,
-            cookie_file_path=f"./data/cookies/cookie-{theme}-mode.json",
-            url=comment.url,
-        )
+        page, browser = await build_browser_context(p, theme=theme, url=comment.url)
 
         # Locate the target comment elements
         comment_header = page.get_by_label(


### PR DESCRIPTION
In this PR I'm adding a parameter and support for downloading screenshots of Reddit posts in `dark` or `light` mode.

**Examples:**
- `dark` theme:
    ![comment_mht7qyu](https://github.com/user-attachments/assets/3556b73e-0e90-47a6-a5e7-329ba7720644)
- `light` theme
    ![comment_mhtjtbv](https://github.com/user-attachments/assets/fb2e5981-d164-4c75-bc5d-e665bd0c275d)
