### PR TITLE
Remove `aresample` to avoid audio cuts in overlay videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,9 @@ pyrightconfig.json
 # Jetbrains
 .idea/
 
+# VSCode
+.vscode/
+
 # Sandbox files
 sandbox.ipynb
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -6252,4 +6252,4 @@ test = ["pytest (>=8.1,<9.0)", "pytest-rerunfailures (>=14.0,<15.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "3.11.*"
-content-hash = "15422e3bb18e1d507580877a6710d56937a2834186f36e9d7b469d8b0212ba01"
+content-hash = "e8bab93252e2eb0c39a8d89f990e57f1b9d78ff8e85e1022124ae02f7e7ba44e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ langid = "^1.1.6"
 torch = "^2.6.0"
 coqui-tts = "^0.26.0"
 accelerate = "^1.4.0"
+numpy = "1.26.4"
 
 [tool.poetry.group.dev.dependencies]
 ipykernel = "^6.29.5"

--- a/src/main.py
+++ b/src/main.py
@@ -54,7 +54,7 @@ def main():
     BACKGROUND_VIDEO_PATH = "assets/posts/{post_id}/video/background_video_{suffix}.mp4"
     BACKGROUND_AUDIO_PATH = "assets/posts/{post_id}/audio/background_audio.mp3"
     BACKGROUND_AUDIO_VOLUME = (
-        0.20  # TODO: we need to change this to use the video duration from settings.
+        0.15  # TODO: we need to change this to use the video duration from settings.
     )
     REEL_PATH = "assets/posts/{post_id}/reel_{suffix}.mp4"
     SPEAKER = "Abrahan Mack"

--- a/src/utils/media/video.py
+++ b/src/utils/media/video.py
@@ -462,11 +462,11 @@ def overlay_videos(
 
         # Overlay the scaled video on top of the background video
         video_out = ffmpeg.overlay(bg.video, ov_scaled, x=x, y=y)
-        bg_audio_fixed = bg.audio.filter("aresample", **{"async": 500}).filter(
+        bg_audio_fixed = bg.audio.filter(
             "volume",
             1.0,
         )
-        ov_audio_fixed = ov.audio.filter("aresample", **{"async": 500}).filter(
+        ov_audio_fixed = ov.audio.filter(
             "volume",
             1.25,
         )

--- a/src/utils/stt.py
+++ b/src/utils/stt.py
@@ -38,7 +38,6 @@ class SpeechToText:
 
         except Exception as e:
             logger.error(f"Error generating transcription segments: {e}")
-            raise e
 
     def generate_srt_file(
         self,
@@ -77,7 +76,6 @@ class SpeechToText:
 
         except Exception as e:
             logger.error(f"Error generating SRT file: {e}")
-            raise e
 
     def srt_to_ass(
         self,
@@ -91,9 +89,10 @@ class SpeechToText:
 
         Args:
             input_file: Path to the SRT file.
-            output_file: Path to the output ASS file. If not provided, it will be generated in the same directory as
-                input_file.
-            config: Configuration dict for ASS v4 Styles+. For more information: http://www.tcax.org/docs/ass-specs.htm
+            output_file: Path to the output ASS file. If not provided, it will be generated in the
+                same directory as input_file.
+            config: Configuration dict for ASS v4 Styles+. For more information:
+                http://www.tcax.org/docs/ass-specs.htm
             delete_srt: Whether to delete the SRT file after conversion. Default is False.
         """
 

--- a/src/utils/tts.py
+++ b/src/utils/tts.py
@@ -25,7 +25,7 @@ class TextToSpeech:
         """  # noqa: W605
 
         # remove any urls from the text
-        regex_urls = r"((http|https)\:\/\/)?[a-zA-Z0-9\.\/\?\:@\-_=#]+\.([a-zA-Z]){2,6}([a-zA-Z0-9\.\&\/\?\:@\-_=#])*"
+        regex_urls = r"((http|https)\:\/\/)?[a-zA-Z0-9\.\/\?\:@\-_=#]+\.([a-zA-Z]){2,6}([a-zA-Z0-9\.\&\/\?\:@\-_=#])*"  # noqa: E501
 
         result = re.sub(regex_urls, " ", text)
 
@@ -90,7 +90,6 @@ class TextToSpeech:
 
         except Exception as e:
             logger.error(f"Error generating audio clip: {e}")
-            raise e
 
 
 tts = TextToSpeech()


### PR DESCRIPTION
In the following PR im improving the video processing by removing the `aresample` to avoid audio cuts.