### PR TITLE
Filter comments without `author` or `body` in `RedditComment`

### DIFF
--- a/src/utils/reddit/post.py
+++ b/src/utils/reddit/post.py
@@ -39,11 +39,12 @@ def parse_reddit_post(thread: praw.models.Submission) -> RedditPost:
                 comment_id=comment.id,
                 post_id=thread.id,
                 body=comment.body,
-                author=comment.author.name if comment.author else "deleted",
+                author=comment.author.name,
                 score=comment.score,
                 permalink=parse_comment_permalink(comment, thread.id),
             )
             for comment in thread.comments
+            if comment.body != "[deleted]" and comment.author
         ],
         num_comments=thread.num_comments,
         tag=thread.link_flair_text,


### PR DESCRIPTION
In this PR, I'm adding a condition to ensure that all comments taken from the Reddit post have a valid author and body. This helps later in identifying the screenshots using Playwright.